### PR TITLE
feat: Add GitHub Actions for CI/CD in Obsidian Plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release Obsidian plugin
 on:
   push:
     tags:
-      - "*"
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 permissions:
   contents: write
@@ -31,7 +31,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Cache pnpm modules
-        id: pnpm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
+        id: pnpm-cache # use this to check for `cache-hit` ==> if: steps.pnpm-cache.outputs.cache-hit != 'true'
         uses: actions/cache@v4
         with:
           path: ~/.pnpm-store

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,13 +52,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           tag="${GITHUB_REF#refs/tags/}"
-          git log $(git describe --tags --abbrev=0)..HEAD --oneline > release-notes.md
+          git log "$(git describe --tags --abbrev=0)"..HEAD --oneline > release-notes.md
     
           # 파일 존재 확인
           files=("manifest.json" "build/main.js" "build/styles.css")
           for file in "${files[@]}"; do
             if [ ! -f "$file" ]; then
-              echo "Error: $file not found"
+              echo "Error: 빌드 결과물 '$file'을 찾을 수 없습니다. 빌드 단계가 성공적으로 완료되었는지 확인해주세요."
               exit 1
             fi
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Release Obsidian plugin
+
+on:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  contents: write
+  issues: write    # Release 노트 작성을 위해
+  pull-requests: write  # Release 관련 PR 필요시
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          version: 9
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Cache pnpm modules
+        id: pnpm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+
+      - name: Install dependencies
+        if: steps.pnpm-cache.outputs.cache-hit != 'true'
+        run: pnpm install
+
+      - name: Build plugin
+        run: pnpm run build
+        continue-on-error: false
+
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          git log $(git describe --tags --abbrev=0)..HEAD --oneline > release-notes.md
+    
+          # 파일 존재 확인
+          files=("manifest.json" "build/main.js" "build/styles.css")
+          for file in "${files[@]}"; do
+            if [ ! -f "$file" ]; then
+              echo "Error: $file not found"
+              exit 1
+            fi
+          done
+    
+          gh release create "$tag" \
+            --title="Release $tag" \
+            --notes-file="release-notes.md" \
+            manifest.json build/main.js build/styles.css

--- a/package.json
+++ b/package.json
@@ -1,15 +1,25 @@
 {
 	"name": "smart-seeker",
 	"version": "1.0.0",
-	"description": "This is a sample plugin for Obsidian (https://obsidian.md)",
+	"description": "An Obsidian plugin that enables fast and intelligent note search using RAG (Retrieval Augmented Generation) with Pinecone vector database and OpenAI",
 	"main": "main.js",
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
 		"version": "node version-bump.mjs && git add manifest.json versions.json"
 	},
-	"keywords": [],
-	"author": "",
+	"keywords": [
+		"obsidian",
+		"obsidian-plugin",
+		"rag",
+		"semantic-search",
+		"vector-search",
+		"pinecone",
+		"openai",
+		"note-search",
+		"knowledge-management",
+	],
+	"author": "anpigon <markan82@gmail.com>",
 	"license": "MIT",
 	"devDependencies": {
 		"@types/node": "^16.11.6",


### PR DESCRIPTION
## Summary
This PR introduces a GitHub Actions workflow to automate the CI/CD process for the Obsidian plugin. The workflow builds and releases the plugin upon tagging.

## Changes
- Added `release.xml` file to define the GitHub Actions workflow.
- Configured steps to:
  - Checkout the code
  - Install Node.js and pnpm
  - Cache dependencies
  - Build the plugin
  - Create a release and upload necessary files (`manifest.json`, `main.js`, `styles.css`).

## Why
Automating the CI/CD process improves development efficiency by streamlining builds and releases, ensuring consistent deployment.

## Notes
- The release process is triggered on a push to a tag matching the pattern `*`.
- Release notes are generated from the commit log.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- GitHub Actions 워크플로우 `release.yml` 추가로 자동화된 릴리스 프로세스 지원.
	- 플러그인의 기능을 설명하는 업데이트된 `package.json`의 설명 필드.
	- 검색 가능성을 높이기 위한 관련 키워드 추가.

- **Bug Fixes**
	- 릴리스 생성 시 필수 파일 누락에 대한 오류 처리 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->